### PR TITLE
use conversion in `setindex!`

### DIFF
--- a/src/TaskLocalValues.jl
+++ b/src/TaskLocalValues.jl
@@ -15,9 +15,8 @@ function Base.getindex(val::TaskLocalValue{T}) where T
 end
 
 function Base.setindex!(val::TaskLocalValue{T}, value) where T
-    Tvalue = convert(T, value)
-    Base.task_local_storage(val, Tvalue)
-    return Tvalue
+    Base.task_local_storage(val, convert(T, value))
+    return value
 end
 
 end # module TaskLocalValues

--- a/src/TaskLocalValues.jl
+++ b/src/TaskLocalValues.jl
@@ -14,9 +14,10 @@ function Base.getindex(val::TaskLocalValue{T}) where T
     get!(()->val.initializer()::T, tls, val)::T
 end
 
-function Base.setindex!(val::TaskLocalValue{T}, value::T) where T
-    Base.task_local_storage(val, value)
-    return value
+function Base.setindex!(val::TaskLocalValue{T}, value) where T
+    Tvalue = convert(T, value)
+    Base.task_local_storage(val, Tvalue)
+    return Tvalue
 end
 
 end # module TaskLocalValues


### PR DESCRIPTION
This makes task local values a little more ergonomic in my experience. 