### PR TITLE
Add TaskLocalValue(initializer) constructor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TaskLocalValues"
 uuid = "ed4db957-447d-4319-bfb6-7fa9ae7ecf34"
 authors = ["Valentin Churavy <v.churavy@gmail.com>"]
-version = "0.1.1"
+version = "0.1.2"
 
 [compat]
 julia = "1.6"

--- a/src/TaskLocalValues.jl
+++ b/src/TaskLocalValues.jl
@@ -5,6 +5,9 @@ export TaskLocalValue
 mutable struct TaskLocalValue{T, F}
     initializer::F
     TaskLocalValue{T}(initializer::F) where {T,F} = new{T,F}(initializer)
+    function TaskLocalValue(initializer::F) where {F}
+        return new{Base.promote_op(initializer), F}(initializer)
+    end
 end
 
 Base.eltype(::TaskLocalValue{T}) where T = T

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,4 +26,7 @@ import Base.Threads: @spawn
     @test !(haskey(Base.task_local_storage(), tlv))
     @test tlv[] == 0
     @test haskey(Base.task_local_storage(), tlv)
+    # Constructor without T (inferred from initializer)
+    tlv2 = TaskLocalValue(() -> 0.0)
+    @test tlv2 isa TaskLocalValue{Float64}
 end


### PR DESCRIPTION
This patch adds another constructor to TaskLocalValue that infers `T` from the initializer, closes #5.